### PR TITLE
Update setup ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Iterm2 is highly customizable and comes with a lot of useful features.
 
 Now that you have homebrew installed:
 ```bash
-brew cask install iterm2
+brew install --cask iterm2
 ```
 
 Let's open up iterm!
@@ -51,7 +51,7 @@ We will come back to themeing zsh, for now lets move on to installing an my favo
 
 ## Installing [VSCode](https://code.visualstudio.com/) (the last ide you will ever need)
 ```bash
-brew cask install visual-studio-code
+brew install --cask visual-studio-code
 ```
 Now you can use `code (file_path|dir_path| )` to open a file, directory, or just the ide itself.
 
@@ -109,7 +109,7 @@ rm -rf fonts
 ```
 
 
-From menu: _Iterm2 -> Preferences -> Profiles -> Default -> Colors -> Color Presets -> {Chose a preset or visit the online gallery to see more}_
+From menu: _Iterm2 -> Settings -> Profiles -> Default -> Colors -> Color Presets -> {Chose a preset or visit the online gallery to see more}_
 
 ** You may want to uncheck Brighten Bold Text
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ chsh -s /usr/local/bin/zsh
 
 Install oh-my zsh
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 ```
 
 We will come back to themeing zsh, for now lets move on to installing an my favourite ide
@@ -65,8 +65,7 @@ Preferences: Open Settings (JSON)
 
 Once settings.json is open add/edit the following keys
 ```bash
-"terminal.integrated.shell.osx": "/bin/zsh",
-"editor.fontFamily": "Source Code Pro for Powerline",
+"editor.fontFamily": "Source Code Pro for Powerline"
 ```
 
 The font isn't available right now; but we will install it below.
@@ -113,13 +112,13 @@ From menu: _Iterm2 -> Settings -> Profiles -> Default -> Colors -> Color Presets
 
 ** You may want to uncheck Brighten Bold Text
 
-In the same profiles section: _Iterm2 -> Preferences -> Profiles -> Default -> Session -> Status Bar Enabled -> Configure Status Bar
+In the same profiles section: _Iterm2 -> Settings -> Profiles -> Default -> Session -> Status Bar Enabled -> Configure Status Bar
 
 Mine looks like this:
 ![](status_bar.png)
 
 
-In the same profiles section: _Iterm2 -> Preferences -> Profiles -> Default -> Text -> Font -> {Choose a Powerline supported font we just installed}
+In the same profiles section: _Iterm2 -> Settings -> Profiles -> Default -> Text -> Font -> {Choose a Powerline supported font we just installed}
 
 ** I use Source Code Pro for Powerline
 
@@ -144,13 +143,6 @@ Add `DEFAULT_USER` env var while you are at it!
 ZSH_THEME="agnoster"
 DEFAULT_USER=`whoami`
 ```
-
-## Install xcode and xcode CLI
-```bash
-xcode-select --install
-```
-
-Next, install XCode from the App Store
 
 ## Install custom python versions
 Mac OS' default python versions are unreliable. It is usually better to install fresh python versions globally to ensure things install/execute adequately.


### PR DESCRIPTION
- homebrew cask syntax changed
- fix ohmyzsh install link
- `terminal.integrated.shell.osx` is deprecated (but zsh is already default so no further needed)
-  Preferences renamed to Settings in iTerm
- XCode installation automatically included in homebrew installation now